### PR TITLE
fix dub import path for windows subpackage

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -23,7 +23,8 @@
             "targetType": "staticLibrary",
             "targetName": "windows",
             "targetPath": "bin",
-            "sourcePaths": ["out/windows"]    
+            "sourcePaths": ["out/windows"],
+            "importPaths": ["out"]
         }
     ]
 }


### PR DESCRIPTION
When `windows-d:windows` is used as a dependency, dub looks in `src/` instead of `out/` and won't find the `windows.*` modules without this.